### PR TITLE
Add doctor appointment minimal API demo

### DIFF
--- a/src/AppointmentApi/Application/DTOs/DoctorDtos.cs
+++ b/src/AppointmentApi/Application/DTOs/DoctorDtos.cs
@@ -1,0 +1,22 @@
+using AppointmentApi.Domain.Enums;
+
+namespace AppointmentApi.Application.DTOs;
+
+public record DoctorCreateRequest(string FirstName, string LastName, string Email, string Specialty, decimal DefaultSlotPrice);
+public record DoctorWorkHoursRequest(TimeOnly WorkStartTime, TimeOnly WorkEndTime);
+public record DoctorLunchRequest(TimeOnly LunchStart, TimeOnly LunchEnd);
+public record DoctorConsultationRequest(int ConsultationDurationMinutes, decimal DefaultSlotPrice);
+public record DoctorResponse(long Id, string FirstName, string LastName, string Specialty, decimal DefaultSlotPrice,
+    TimeOnly WorkStartTime, TimeOnly WorkEndTime, TimeOnly LunchStart, TimeOnly LunchEnd, int ConsultationDurationMinutes);
+
+public record GenerateSlotsRequest(DateOnly Date, decimal? CustomPrice);
+public record SlotResponse(long Id, long DoctorId, DateTime StartTimeUtc, DateTime EndTimeUtc, decimal Price, bool IsBooked);
+
+public record BookSlotRequest(long PatientId, long SlotId, PaymentMethod PaymentMethod);
+public record AppointmentResponse(long Id, long DoctorId, long PatientId, DateTime StartUtc, AppointmentStatus Status,
+    decimal Price, PaymentStatus PaymentStatus);
+
+public record ApproveDeclineRequest(long AppointmentId);
+public record CancelAppointmentRequest(long AppointmentId);
+public record SetAppointmentStatusRequest(AppointmentStatus Status);
+public record RefundPaymentRequest(long PaymentId);

--- a/src/AppointmentApi/Application/Services/AdminService.cs
+++ b/src/AppointmentApi/Application/Services/AdminService.cs
@@ -1,0 +1,46 @@
+using AppointmentApi.Domain.Entities;
+using AppointmentApi.Domain.Enums;
+using AppointmentApi.Infrastructure.Repositories;
+
+namespace AppointmentApi.Application.Services;
+
+public class AdminService
+{
+    private readonly IDoctorRepository _doctors;
+    private readonly IPatientRepository _patients;
+    private readonly IAppointmentRepository _appointments;
+    private readonly IPaymentRepository _payments;
+    private readonly IScheduleSlotRepository _slots;
+    private readonly PaymentService _paymentService;
+
+    public AdminService(IDoctorRepository doctors, IPatientRepository patients,
+        IAppointmentRepository appointments, IPaymentRepository payments,
+        IScheduleSlotRepository slots, PaymentService paymentService)
+    {
+        _doctors = doctors;
+        _patients = patients;
+        _appointments = appointments;
+        _payments = payments;
+        _slots = slots;
+        _paymentService = paymentService;
+    }
+
+    public Task<List<Doctor>> ListDoctors() => _doctors.ListAsync();
+    public Task<List<Patient>> ListPatients() => _patients.ListAsync();
+    public Task<List<Appointment>> ListAppointments() => _appointments.ListAsync();
+    public Task<List<Payment>> ListPayments() => _payments.ListAsync();
+
+    public async Task SetAppointmentStatus(long id, AppointmentStatus status)
+    {
+        var appt = await _appointments.GetWithPayment(id) ?? throw new ArgumentException("not found");
+        appt.Status = status;
+        await _appointments.UpdateAsync(appt);
+        await _appointments.SaveChangesAsync();
+    }
+
+    public async Task<bool> RefundPayment(long paymentId)
+    {
+        var payment = await _payments.GetByIdAsync(paymentId) ?? throw new ArgumentException("not found");
+        return await _paymentService.RefundAsync(payment);
+    }
+}

--- a/src/AppointmentApi/Application/Services/BookingService.cs
+++ b/src/AppointmentApi/Application/Services/BookingService.cs
@@ -1,0 +1,64 @@
+using AppointmentApi.Domain.Entities;
+using AppointmentApi.Domain.Enums;
+using AppointmentApi.Infrastructure.Repositories;
+
+namespace AppointmentApi.Application.Services;
+
+public class BookingService
+{
+    private readonly IScheduleSlotRepository _slots;
+    private readonly IAppointmentRepository _appointments;
+    private readonly IPatientRepository _patients;
+    private readonly IDoctorRepository _doctors;
+    private readonly PaymentService _payments;
+
+    public BookingService(IScheduleSlotRepository slots, IAppointmentRepository appointments,
+        IPatientRepository patients, IDoctorRepository doctors, PaymentService payments)
+    {
+        _slots = slots;
+        _appointments = appointments;
+        _patients = patients;
+        _doctors = doctors;
+        _payments = payments;
+    }
+
+    public async Task<Appointment> BookSlot(long patientId, long slotId, PaymentMethod method)
+    {
+        var slot = await _slots.GetByIdAsync(slotId) ?? throw new ArgumentException("Slot not found");
+        if (slot.IsBooked) throw new InvalidOperationException("Slot already booked");
+        var patient = await _patients.GetByIdAsync(patientId) ?? throw new ArgumentException("Patient not found");
+        var doctor = await _doctors.GetByIdAsync(slot.DoctorId) ?? throw new ArgumentException("Doctor not found");
+        var duration = slot.EndTimeUtc - slot.StartTimeUtc;
+        if (duration.TotalMinutes != doctor.ConsultationDurationMinutes)
+            throw new InvalidOperationException("Slot duration mismatch");
+
+        var appointment = new Appointment
+        {
+            DoctorId = doctor.Id,
+            PatientId = patient.Id,
+            ScheduleSlotId = slot.Id,
+            AppointmentDateUtc = slot.StartTimeUtc,
+            Status = AppointmentStatus.Pending,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+        await _appointments.AddAsync(appointment);
+        await _appointments.SaveChangesAsync();
+
+        var payment = await _payments.ChargeAsync(appointment, method);
+        appointment.Payment = payment;
+        if (payment.Status == PaymentStatus.Succeeded)
+        {
+            slot.IsBooked = true;
+            slot.AppointmentId = appointment.Id;
+            await _slots.UpdateAsync(slot);
+            await _slots.SaveChangesAsync();
+        }
+        else
+        {
+            appointment.Status = AppointmentStatus.Cancelled;
+            await _appointments.UpdateAsync(appointment);
+            await _appointments.SaveChangesAsync();
+        }
+        return appointment;
+    }
+}

--- a/src/AppointmentApi/Application/Services/DoctorDecisionService.cs
+++ b/src/AppointmentApi/Application/Services/DoctorDecisionService.cs
@@ -1,0 +1,53 @@
+using AppointmentApi.Domain.Enums;
+using AppointmentApi.Infrastructure.Repositories;
+
+namespace AppointmentApi.Application.Services;
+
+public class DoctorDecisionService
+{
+    private readonly IAppointmentRepository _appointments;
+    private readonly IScheduleSlotRepository _slots;
+    private readonly IPaymentRepository _payments;
+    private readonly PaymentService _paymentService;
+
+    public DoctorDecisionService(IAppointmentRepository appointments, IScheduleSlotRepository slots,
+        IPaymentRepository payments, PaymentService paymentService)
+    {
+        _appointments = appointments;
+        _slots = slots;
+        _payments = payments;
+        _paymentService = paymentService;
+    }
+
+    public async Task ApproveAsync(long doctorId, long appointmentId)
+    {
+        var appt = await _appointments.GetWithPayment(appointmentId) ?? throw new ArgumentException("Not found");
+        if (appt.DoctorId != doctorId) throw new UnauthorizedAccessException();
+        if (appt.Status != AppointmentStatus.Pending) throw new InvalidOperationException();
+        appt.Status = AppointmentStatus.Approved;
+        await _appointments.UpdateAsync(appt);
+        await _appointments.SaveChangesAsync();
+    }
+
+    public async Task DeclineAsync(long doctorId, long appointmentId)
+    {
+        var appt = await _appointments.GetWithPayment(appointmentId) ?? throw new ArgumentException("Not found");
+        if (appt.DoctorId != doctorId) throw new UnauthorizedAccessException();
+        if (appt.Status != AppointmentStatus.Pending) throw new InvalidOperationException();
+        appt.Status = AppointmentStatus.Cancelled;
+        await _appointments.UpdateAsync(appt);
+
+        var slot = await _slots.GetByIdAsync(appt.ScheduleSlotId) ?? throw new ArgumentException("slot");
+        slot.IsBooked = false;
+        slot.AppointmentId = null;
+        await _slots.UpdateAsync(slot);
+
+        if (appt.Payment != null && appt.Payment.Status == PaymentStatus.Succeeded)
+        {
+            await _paymentService.RefundAsync(appt.Payment);
+        }
+
+        await _slots.SaveChangesAsync();
+        await _appointments.SaveChangesAsync();
+    }
+}

--- a/src/AppointmentApi/Application/Services/IPaymentProvider.cs
+++ b/src/AppointmentApi/Application/Services/IPaymentProvider.cs
@@ -1,0 +1,13 @@
+namespace AppointmentApi.Application.Services;
+
+public interface IPaymentProvider
+{
+    Task<bool> ChargeAsync(decimal amount, string currency);
+    Task<bool> RefundAsync(long paymentId);
+}
+
+public class FakePaymentProvider : IPaymentProvider
+{
+    public Task<bool> ChargeAsync(decimal amount, string currency) => Task.FromResult(true);
+    public Task<bool> RefundAsync(long paymentId) => Task.FromResult(true);
+}

--- a/src/AppointmentApi/Application/Services/PatientService.cs
+++ b/src/AppointmentApi/Application/Services/PatientService.cs
@@ -1,0 +1,41 @@
+using AppointmentApi.Domain.Enums;
+using AppointmentApi.Infrastructure.Repositories;
+
+namespace AppointmentApi.Application.Services;
+
+public class PatientService
+{
+    private readonly IAppointmentRepository _appointments;
+    private readonly IScheduleSlotRepository _slots;
+    private readonly PaymentService _paymentService;
+
+    public PatientService(IAppointmentRepository appointments, IScheduleSlotRepository slots,
+        PaymentService paymentService)
+    {
+        _appointments = appointments;
+        _slots = slots;
+        _paymentService = paymentService;
+    }
+
+    public async Task<bool> CancelAsync(long patientId, long appointmentId)
+    {
+        var appt = await _appointments.GetWithPayment(appointmentId) ?? throw new ArgumentException("Not found");
+        if (appt.PatientId != patientId) throw new UnauthorizedAccessException();
+        if (appt.Status != AppointmentStatus.Pending && appt.Status != AppointmentStatus.Approved)
+            throw new InvalidOperationException();
+        var slot = await _slots.GetByIdAsync(appt.ScheduleSlotId) ?? throw new ArgumentException("Slot");
+        bool refunded = false;
+        if (DateTime.UtcNow < slot.StartTimeUtc && appt.Payment != null && appt.Payment.Status == PaymentStatus.Succeeded)
+        {
+            refunded = await _paymentService.RefundAsync(appt.Payment);
+        }
+        appt.Status = AppointmentStatus.Cancelled;
+        slot.IsBooked = false;
+        slot.AppointmentId = null;
+        await _appointments.UpdateAsync(appt);
+        await _slots.UpdateAsync(slot);
+        await _slots.SaveChangesAsync();
+        await _appointments.SaveChangesAsync();
+        return refunded;
+    }
+}

--- a/src/AppointmentApi/Application/Services/PaymentService.cs
+++ b/src/AppointmentApi/Application/Services/PaymentService.cs
@@ -1,0 +1,51 @@
+using AppointmentApi.Domain.Entities;
+using AppointmentApi.Domain.Enums;
+using AppointmentApi.Infrastructure.Repositories;
+
+namespace AppointmentApi.Application.Services;
+
+public class PaymentService
+{
+    private readonly IPaymentProvider _provider;
+    private readonly IPaymentRepository _payments;
+
+    public PaymentService(IPaymentProvider provider, IPaymentRepository payments)
+    {
+        _provider = provider;
+        _payments = payments;
+    }
+
+    public async Task<Payment> ChargeAsync(Appointment appointment, PaymentMethod method)
+    {
+        var payment = new Payment
+        {
+            AppointmentId = appointment.Id,
+            Amount = appointment.ScheduleSlot.Price,
+            Currency = "USD",
+            Method = method,
+            Status = PaymentStatus.Pending,
+            CreatedAtUtc = DateTime.UtcNow,
+            UpdatedAtUtc = DateTime.UtcNow
+        };
+        await _payments.AddAsync(payment);
+        var ok = await _provider.ChargeAsync(payment.Amount, payment.Currency);
+        payment.Status = ok ? PaymentStatus.Succeeded : PaymentStatus.Failed;
+        payment.UpdatedAtUtc = DateTime.UtcNow;
+        await _payments.SaveChangesAsync();
+        return payment;
+    }
+
+    public async Task<bool> RefundAsync(Payment payment)
+    {
+        var ok = await _provider.RefundAsync(payment.Id);
+        if (ok)
+        {
+            payment.Status = PaymentStatus.Refunded;
+            payment.UpdatedAtUtc = DateTime.UtcNow;
+            await _payments.UpdateAsync(payment);
+            await _payments.SaveChangesAsync();
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/AppointmentApi/Application/Services/SchedulingService.cs
+++ b/src/AppointmentApi/Application/Services/SchedulingService.cs
@@ -1,0 +1,51 @@
+using AppointmentApi.Domain.Entities;
+using AppointmentApi.Infrastructure.Repositories;
+
+namespace AppointmentApi.Application.Services;
+
+public class SchedulingService
+{
+    private readonly IDoctorRepository _doctors;
+    private readonly IScheduleSlotRepository _slots;
+
+    public SchedulingService(IDoctorRepository doctors, IScheduleSlotRepository slots)
+    {
+        _doctors = doctors;
+        _slots = slots;
+    }
+
+    public async Task<List<ScheduleSlot>> GenerateDailySlots(long doctorId, DateOnly date, decimal? customPrice = null)
+    {
+        var doctor = await _doctors.GetByIdAsync(doctorId) ?? throw new ArgumentException("Doctor not found");
+        var slots = new List<ScheduleSlot>();
+        var current = date.ToDateTime(doctor.WorkStartTime, DateTimeKind.Utc);
+        var end = date.ToDateTime(doctor.WorkEndTime, DateTimeKind.Utc);
+        var lunchStart = date.ToDateTime(doctor.LunchStart, DateTimeKind.Utc);
+        var lunchEnd = date.ToDateTime(doctor.LunchEnd, DateTimeKind.Utc);
+        var duration = TimeSpan.FromMinutes(doctor.ConsultationDurationMinutes);
+        while (current + duration <= end)
+        {
+            var next = current + duration;
+            if (!(current < lunchEnd && next > lunchStart))
+            {
+                if (!await _slots.ExistsOverlap(doctorId, current, next))
+                {
+                    var slot = new ScheduleSlot
+                    {
+                        DoctorId = doctorId,
+                        StartTimeUtc = current,
+                        EndTimeUtc = next,
+                        Price = customPrice ?? doctor.DefaultSlotPrice,
+                        IsBooked = false
+                    };
+                    await _slots.AddAsync(slot);
+                    slots.Add(slot);
+                }
+            }
+            current = next;
+        }
+        if (slots.Any())
+            await _slots.SaveChangesAsync();
+        return slots;
+    }
+}

--- a/src/AppointmentApi/AppointmentApi.csproj
+++ b/src/AppointmentApi/AppointmentApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/AppointmentApi/Domain/Entities/Appointment.cs
+++ b/src/AppointmentApi/Domain/Entities/Appointment.cs
@@ -1,0 +1,18 @@
+using AppointmentApi.Domain.Enums;
+
+namespace AppointmentApi.Domain.Entities;
+
+public class Appointment
+{
+    public long Id { get; set; }
+    public long DoctorId { get; set; }
+    public Doctor Doctor { get; set; } = null!;
+    public long PatientId { get; set; }
+    public Patient Patient { get; set; } = null!;
+    public long ScheduleSlotId { get; set; }
+    public ScheduleSlot ScheduleSlot { get; set; } = null!;
+    public DateTime AppointmentDateUtc { get; set; }
+    public AppointmentStatus Status { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public Payment? Payment { get; set; }
+}

--- a/src/AppointmentApi/Domain/Entities/Doctor.cs
+++ b/src/AppointmentApi/Domain/Entities/Doctor.cs
@@ -1,0 +1,23 @@
+namespace AppointmentApi.Domain.Entities;
+
+public class Doctor
+{
+    public long Id { get; set; }
+    public long UserId { get; set; }
+    public User User { get; set; } = null!;
+    public string Specialty { get; set; } = string.Empty;
+    public decimal? Rating { get; set; }
+    public string? Description { get; set; }
+    public int? Experience { get; set; }
+    public bool IsConfirmedByAdmin { get; set; }
+    public TimeOnly WorkStartTime { get; set; }
+    public TimeOnly WorkEndTime { get; set; }
+    public TimeOnly LunchStart { get; set; }
+    public TimeOnly LunchEnd { get; set; }
+    public int ConsultationDurationMinutes { get; set; } = 60;
+    public decimal DefaultSlotPrice { get; set; }
+    public long? HospitalId { get; set; }
+    public Hospital? Hospital { get; set; }
+    public ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+    public ICollection<ScheduleSlot> ScheduleSlots { get; set; } = new List<ScheduleSlot>();
+}

--- a/src/AppointmentApi/Domain/Entities/Hospital.cs
+++ b/src/AppointmentApi/Domain/Entities/Hospital.cs
@@ -1,0 +1,7 @@
+namespace AppointmentApi.Domain.Entities;
+
+public class Hospital
+{
+    public long Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/AppointmentApi/Domain/Entities/Patient.cs
+++ b/src/AppointmentApi/Domain/Entities/Patient.cs
@@ -1,0 +1,11 @@
+namespace AppointmentApi.Domain.Entities;
+
+public class Patient
+{
+    public long Id { get; set; }
+    public long UserId { get; set; }
+    public User User { get; set; } = null!;
+    public DateTime? DateOfBirth { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+}

--- a/src/AppointmentApi/Domain/Entities/Payment.cs
+++ b/src/AppointmentApi/Domain/Entities/Payment.cs
@@ -1,0 +1,17 @@
+using AppointmentApi.Domain.Enums;
+
+namespace AppointmentApi.Domain.Entities;
+
+public class Payment
+{
+    public long Id { get; set; }
+    public long AppointmentId { get; set; }
+    public Appointment Appointment { get; set; } = null!;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public PaymentStatus Status { get; set; }
+    public PaymentMethod Method { get; set; }
+    public string? ExternalRef { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime UpdatedAtUtc { get; set; }
+}

--- a/src/AppointmentApi/Domain/Entities/ScheduleSlot.cs
+++ b/src/AppointmentApi/Domain/Entities/ScheduleSlot.cs
@@ -1,0 +1,14 @@
+namespace AppointmentApi.Domain.Entities;
+
+public class ScheduleSlot
+{
+    public long Id { get; set; }
+    public long DoctorId { get; set; }
+    public Doctor Doctor { get; set; } = null!;
+    public DateTime StartTimeUtc { get; set; }
+    public DateTime EndTimeUtc { get; set; }
+    public decimal Price { get; set; }
+    public bool IsBooked { get; set; }
+    public long? AppointmentId { get; set; }
+    public Appointment? Appointment { get; set; }
+}

--- a/src/AppointmentApi/Domain/Entities/User.cs
+++ b/src/AppointmentApi/Domain/Entities/User.cs
@@ -1,0 +1,12 @@
+using AppointmentApi.Domain.Enums;
+
+namespace AppointmentApi.Domain.Entities;
+
+public class User
+{
+    public long Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public UserRole Role { get; set; }
+}

--- a/src/AppointmentApi/Domain/Enums/AppointmentStatus.cs
+++ b/src/AppointmentApi/Domain/Enums/AppointmentStatus.cs
@@ -1,0 +1,9 @@
+namespace AppointmentApi.Domain.Enums;
+
+public enum AppointmentStatus
+{
+    Pending,
+    Approved,
+    Cancelled,
+    Completed
+}

--- a/src/AppointmentApi/Domain/Enums/PaymentMethod.cs
+++ b/src/AppointmentApi/Domain/Enums/PaymentMethod.cs
@@ -1,0 +1,8 @@
+namespace AppointmentApi.Domain.Enums;
+
+public enum PaymentMethod
+{
+    Card,
+    Cash,
+    Other
+}

--- a/src/AppointmentApi/Domain/Enums/PaymentStatus.cs
+++ b/src/AppointmentApi/Domain/Enums/PaymentStatus.cs
@@ -1,0 +1,9 @@
+namespace AppointmentApi.Domain.Enums;
+
+public enum PaymentStatus
+{
+    Pending,
+    Succeeded,
+    Failed,
+    Refunded
+}

--- a/src/AppointmentApi/Domain/Enums/UserRole.cs
+++ b/src/AppointmentApi/Domain/Enums/UserRole.cs
@@ -1,0 +1,8 @@
+namespace AppointmentApi.Domain.Enums;
+
+public enum UserRole
+{
+    Admin,
+    Doctor,
+    Patient
+}

--- a/src/AppointmentApi/Infrastructure/AppDbContext.cs
+++ b/src/AppointmentApi/Infrastructure/AppDbContext.cs
@@ -1,0 +1,29 @@
+using AppointmentApi.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AppointmentApi.Infrastructure;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Doctor> Doctors => Set<Doctor>();
+    public DbSet<Patient> Patients => Set<Patient>();
+    public DbSet<ScheduleSlot> ScheduleSlots => Set<ScheduleSlot>();
+    public DbSet<Appointment> Appointments => Set<Appointment>();
+    public DbSet<Payment> Payments => Set<Payment>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ScheduleSlot>()
+            .Property(s => s.Price)
+            .HasPrecision(18, 2);
+
+        modelBuilder.Entity<Payment>()
+            .Property(p => p.Amount)
+            .HasPrecision(18, 2);
+    }
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/AppointmentRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/AppointmentRepository.cs
@@ -1,0 +1,26 @@
+using AppointmentApi.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public class AppointmentRepository : Repository<Appointment>, IAppointmentRepository
+{
+    public AppointmentRepository(AppDbContext db) : base(db)
+    {
+    }
+
+    public async Task<List<Appointment>> ListByDoctor(long doctorId)
+        => await _db.Appointments.Where(a => a.DoctorId == doctorId)
+            .Include(a => a.ScheduleSlot)
+            .Include(a => a.Patient).ToListAsync();
+
+    public async Task<List<Appointment>> ListByPatient(long patientId)
+        => await _db.Appointments.Where(a => a.PatientId == patientId)
+            .Include(a => a.ScheduleSlot)
+            .Include(a => a.Doctor).ToListAsync();
+
+    public async Task<Appointment?> GetWithPayment(long id)
+        => await _db.Appointments.Include(a => a.Payment)
+            .Include(a => a.ScheduleSlot)
+            .FirstOrDefaultAsync(a => a.Id == id);
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/DoctorRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/DoctorRepository.cs
@@ -1,0 +1,10 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public class DoctorRepository : Repository<Doctor>, IDoctorRepository
+{
+    public DoctorRepository(AppDbContext db) : base(db)
+    {
+    }
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/IAppointmentRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/IAppointmentRepository.cs
@@ -1,0 +1,10 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public interface IAppointmentRepository : IRepository<Appointment>
+{
+    Task<List<Appointment>> ListByDoctor(long doctorId);
+    Task<List<Appointment>> ListByPatient(long patientId);
+    Task<Appointment?> GetWithPayment(long id);
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/IDoctorRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/IDoctorRepository.cs
@@ -1,0 +1,7 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public interface IDoctorRepository : IRepository<Doctor>
+{
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/IPatientRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/IPatientRepository.cs
@@ -1,0 +1,7 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public interface IPatientRepository : IRepository<Patient>
+{
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/IPaymentRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/IPaymentRepository.cs
@@ -1,0 +1,8 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public interface IPaymentRepository : IRepository<Payment>
+{
+    Task<Payment?> GetByAppointmentId(long appointmentId);
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/IRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/IRepository.cs
@@ -1,0 +1,11 @@
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public interface IRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(long id);
+    Task<List<T>> ListAsync();
+    Task AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(T entity);
+    Task SaveChangesAsync();
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/IScheduleSlotRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/IScheduleSlotRepository.cs
@@ -1,0 +1,9 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public interface IScheduleSlotRepository : IRepository<ScheduleSlot>
+{
+    Task<List<ScheduleSlot>> ListAvailableByDoctorAndDate(long doctorId, DateOnly date);
+    Task<bool> ExistsOverlap(long doctorId, DateTime startUtc, DateTime endUtc);
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/PatientRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/PatientRepository.cs
@@ -1,0 +1,10 @@
+using AppointmentApi.Domain.Entities;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public class PatientRepository : Repository<Patient>, IPatientRepository
+{
+    public PatientRepository(AppDbContext db) : base(db)
+    {
+    }
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/PaymentRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/PaymentRepository.cs
@@ -1,0 +1,14 @@
+using AppointmentApi.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public class PaymentRepository : Repository<Payment>, IPaymentRepository
+{
+    public PaymentRepository(AppDbContext db) : base(db)
+    {
+    }
+
+    public async Task<Payment?> GetByAppointmentId(long appointmentId)
+        => await _db.Payments.FirstOrDefaultAsync(p => p.AppointmentId == appointmentId);
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/Repository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/Repository.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public class Repository<T> : IRepository<T> where T : class
+{
+    protected readonly AppDbContext _db;
+    public Repository(AppDbContext db) => _db = db;
+
+    public async Task<T?> GetByIdAsync(long id) => await _db.Set<T>().FindAsync(id);
+
+    public async Task<List<T>> ListAsync() => await _db.Set<T>().ToListAsync();
+
+    public async Task AddAsync(T entity)
+    {
+        await _db.Set<T>().AddAsync(entity);
+    }
+
+    public Task UpdateAsync(T entity)
+    {
+        _db.Set<T>().Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(T entity)
+    {
+        _db.Set<T>().Remove(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task SaveChangesAsync() => await _db.SaveChangesAsync();
+}

--- a/src/AppointmentApi/Infrastructure/Repositories/ScheduleSlotRepository.cs
+++ b/src/AppointmentApi/Infrastructure/Repositories/ScheduleSlotRepository.cs
@@ -1,0 +1,27 @@
+using AppointmentApi.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AppointmentApi.Infrastructure.Repositories;
+
+public class ScheduleSlotRepository : Repository<ScheduleSlot>, IScheduleSlotRepository
+{
+    public ScheduleSlotRepository(AppDbContext db) : base(db)
+    {
+    }
+
+    public async Task<List<ScheduleSlot>> ListAvailableByDoctorAndDate(long doctorId, DateOnly date)
+    {
+        var start = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var end = date.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
+        return await _db.ScheduleSlots
+            .Where(s => s.DoctorId == doctorId && !s.IsBooked && s.StartTimeUtc >= start && s.StartTimeUtc < end)
+            .OrderBy(s => s.StartTimeUtc)
+            .ToListAsync();
+    }
+
+    public async Task<bool> ExistsOverlap(long doctorId, DateTime startUtc, DateTime endUtc)
+    {
+        return await _db.ScheduleSlots.AnyAsync(s => s.DoctorId == doctorId &&
+            ((startUtc < s.EndTimeUtc) && (endUtc > s.StartTimeUtc)));
+    }
+}

--- a/src/AppointmentApi/Program.cs
+++ b/src/AppointmentApi/Program.cs
@@ -1,0 +1,197 @@
+using AppointmentApi.Application.DTOs;
+using AppointmentApi.Application.Services;
+using AppointmentApi.Domain.Entities;
+using AppointmentApi.Domain.Enums;
+using AppointmentApi.Infrastructure;
+using AppointmentApi.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(o => o.UseInMemoryDatabase("app"));
+
+builder.Services.AddScoped<IDoctorRepository, DoctorRepository>();
+builder.Services.AddScoped<IPatientRepository, PatientRepository>();
+builder.Services.AddScoped<IScheduleSlotRepository, ScheduleSlotRepository>();
+builder.Services.AddScoped<IAppointmentRepository, AppointmentRepository>();
+builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
+
+builder.Services.AddScoped<IPaymentProvider, FakePaymentProvider>();
+builder.Services.AddScoped<PaymentService>();
+builder.Services.AddScoped<SchedulingService>();
+builder.Services.AddScoped<BookingService>();
+builder.Services.AddScoped<DoctorDecisionService>();
+builder.Services.AddScoped<PatientService>();
+builder.Services.AddScoped<AdminService>();
+
+var app = builder.Build();
+
+// Doctor endpoints
+app.MapPost("/api/doctors", async ([FromBody] DoctorCreateRequest req, IDoctorRepository repo) =>
+{
+    var doctor = new Doctor
+    {
+        User = new User { FirstName = req.FirstName, LastName = req.LastName, Email = req.Email, Role = UserRole.Doctor },
+        Specialty = req.Specialty,
+        DefaultSlotPrice = req.DefaultSlotPrice
+    };
+    await repo.AddAsync(doctor);
+    await repo.SaveChangesAsync();
+    return Results.Ok(new { data = doctor });
+});
+
+app.MapPut("/api/doctors/{id}/work-hours", async (long id, DoctorWorkHoursRequest req, IDoctorRepository repo) =>
+{
+    var doctor = await repo.GetByIdAsync(id); if (doctor == null) return Results.NotFound();
+    doctor.WorkStartTime = req.WorkStartTime;
+    doctor.WorkEndTime = req.WorkEndTime;
+    await repo.UpdateAsync(doctor);
+    await repo.SaveChangesAsync();
+    return Results.Ok(new { data = doctor });
+});
+
+app.MapPut("/api/doctors/{id}/lunch", async (long id, DoctorLunchRequest req, IDoctorRepository repo) =>
+{
+    var doctor = await repo.GetByIdAsync(id); if (doctor == null) return Results.NotFound();
+    doctor.LunchStart = req.LunchStart;
+    doctor.LunchEnd = req.LunchEnd;
+    await repo.UpdateAsync(doctor);
+    await repo.SaveChangesAsync();
+    return Results.Ok(new { data = doctor });
+});
+
+app.MapPut("/api/doctors/{id}/consultation", async (long id, DoctorConsultationRequest req, IDoctorRepository repo) =>
+{
+    var doctor = await repo.GetByIdAsync(id); if (doctor == null) return Results.NotFound();
+    doctor.ConsultationDurationMinutes = req.ConsultationDurationMinutes;
+    doctor.DefaultSlotPrice = req.DefaultSlotPrice;
+    await repo.UpdateAsync(doctor);
+    await repo.SaveChangesAsync();
+    return Results.Ok(new { data = doctor });
+});
+
+app.MapGet("/api/doctors", async (IDoctorRepository repo) =>
+{
+    var docs = await repo.ListAsync();
+    return Results.Ok(new { data = docs });
+});
+
+app.MapGet("/api/doctors/{id}", async (long id, IDoctorRepository repo) =>
+{
+    var doc = await repo.GetByIdAsync(id);
+    return doc == null ? Results.NotFound() : Results.Ok(new { data = doc });
+});
+
+// Scheduling
+app.MapPost("/api/scheduling/{doctorId}/generate-slots", async (long doctorId, [FromBody] GenerateSlotsRequest req, SchedulingService svc) =>
+{
+    var slots = await svc.GenerateDailySlots(doctorId, req.Date, req.CustomPrice);
+    return Results.Ok(new { data = slots });
+});
+
+app.MapGet("/api/slots/doctor/{doctorId}", async (long doctorId, DateOnly date, IScheduleSlotRepository repo) =>
+{
+    var slots = await repo.ListAvailableByDoctorAndDate(doctorId, date);
+    return Results.Ok(new { data = slots });
+});
+
+// Booking / Appointments
+app.MapPost("/api/appointments/book", async (BookSlotRequest req, BookingService svc) =>
+{
+    try
+    {
+        var appt = await svc.BookSlot(req.PatientId, req.SlotId, req.PaymentMethod);
+        return Results.Ok(new { data = appt });
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+});
+
+app.MapPost("/api/appointments/{id}/approve", async (long id, DoctorDecisionService svc, long doctorId) =>
+{
+    try
+    {
+        await svc.ApproveAsync(doctorId, id);
+        return Results.Ok(new { data = true });
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+});
+
+app.MapPost("/api/appointments/{id}/decline", async (long id, DoctorDecisionService svc, long doctorId) =>
+{
+    try
+    {
+        await svc.DeclineAsync(doctorId, id);
+        return Results.Ok(new { data = true });
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+});
+
+app.MapPost("/api/appointments/{id}/cancel", async (long id, long patientId, PatientService svc) =>
+{
+    try
+    {
+        var refunded = await svc.CancelAsync(patientId, id);
+        return Results.Ok(new { data = refunded });
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+});
+
+app.MapGet("/api/appointments/doctor/{doctorId}", async (long doctorId, IAppointmentRepository repo) =>
+{
+    var list = await repo.ListByDoctor(doctorId);
+    return Results.Ok(new { data = list });
+});
+
+app.MapGet("/api/appointments/patient/{patientId}", async (long patientId, IAppointmentRepository repo) =>
+{
+    var list = await repo.ListByPatient(patientId);
+    return Results.Ok(new { data = list });
+});
+
+// Payments
+app.MapGet("/api/payments/appointment/{appointmentId}", async (long appointmentId, IPaymentRepository repo) =>
+{
+    var payment = await repo.GetByAppointmentId(appointmentId);
+    return payment == null ? Results.NotFound() : Results.Ok(new { data = payment });
+});
+
+app.MapPost("/api/payments/{paymentId}/refund", async (long paymentId, PaymentService svc, IPaymentRepository repo) =>
+{
+    var payment = await repo.GetByIdAsync(paymentId);
+    if (payment == null) return Results.NotFound();
+    var ok = await svc.RefundAsync(payment);
+    return Results.Ok(new { data = ok });
+});
+
+// Admin
+app.MapGet("/api/admin/doctors", async (AdminService svc) => Results.Ok(new { data = await svc.ListDoctors() }));
+app.MapGet("/api/admin/patients", async (AdminService svc) => Results.Ok(new { data = await svc.ListPatients() }));
+app.MapGet("/api/admin/appointments", async (AdminService svc) => Results.Ok(new { data = await svc.ListAppointments() }));
+app.MapGet("/api/admin/payments", async (AdminService svc) => Results.Ok(new { data = await svc.ListPayments() }));
+
+app.MapPost("/api/admin/appointments/{id}/status", async (long id, SetAppointmentStatusRequest req, AdminService svc) =>
+{
+    await svc.SetAppointmentStatus(id, req.Status);
+    return Results.Ok(new { data = true });
+});
+
+app.MapPost("/api/admin/payments/{id}/refund", async (long id, AdminService svc) =>
+{
+    var ok = await svc.RefundPayment(id);
+    return Results.Ok(new { data = ok });
+});
+
+app.Run();


### PR DESCRIPTION
## Summary
- add domain entities and enums for appointments, schedules, payments and users
- implement EF repositories and business services for scheduling, booking, and payments
- expose minimal API endpoints for doctors, slots, booking, payments and admin operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c72b2098c83309dab7347dcdbe413